### PR TITLE
Various changes

### DIFF
--- a/bin/ffss-git-server-pre-commit.pl
+++ b/bin/ffss-git-server-pre-commit.pl
@@ -44,7 +44,8 @@ my $GID     = 1;
 GetOptions ( "dbname=s" => \$MONGOTBL
            , "dbhost:s" => \$MONGOHOST
            , "dbuser:s" => \$MONGOUSER
-           , "dbpass:s" => \$MONGOPASS);
+           , "dbpass:s" => \$MONGOPASS
+           , "rulesdir:s" => \$RULESDIR);
 my $MONGOTBL_C = $MONGOTBL ."_current";
 
 my $rules = {};


### PR DESCRIPTION
Only use one connection to MongoDB, and allow for authenticated connections. Also let the user specify the directory within the repository containing the rules.
